### PR TITLE
Added better checkout syntax

### DIFF
--- a/.github/workflows/copy-changelog.yml
+++ b/.github/workflows/copy-changelog.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ImaanBontleRepoActionToken }}
           
       - name: Grab Updated Changelog
-        run: git fetch && git checkout develop CHANGELOG.md
+        run: git fetch && git checkout refs/remotes/origin/develop CHANGELOG.md
         env:
           GH_TOKEN: ${{ secrets.ImaanBontleRepoActionToken }}
           


### PR DESCRIPTION
Workflow should now point to the location on remote where develop is kept