### PR TITLE
Fixed incorrect weather check for Spring 1-4

### DIFF
--- a/WeatherSlotMachine.cs
+++ b/WeatherSlotMachine.cs
@@ -161,10 +161,9 @@ namespace IW_ClimateControl
             // Check possibilities
             switch (currentDate.TotalDays)
             {
+                case 0:
                 case 1:
                 case 2:
-                case 3:
-                case 4:
                     // Too early in game.
                     canChange = false;
                     reason = "the player has played too few days on this save.";


### PR DESCRIPTION
Mod was incorrectly applying weather changes on Spring 1 and none on
Spring 4. This has been fixed.
